### PR TITLE
Increase waiting time to reduce cpu usage

### DIFF
--- a/bme280.js
+++ b/bme280.js
@@ -155,7 +155,7 @@ module.exports = class Bme280 {
       // wait until measurement has been completed, 
       // otherwise we would read the values from the last measurement
       while ((await this._readRegister(this.register.STATUS)) && 0b1000) {
-        await this._sleep(4);
+        await this._sleep(80);
       }
     }).catch(err => {
       this._logError(`Could not set mode ${newMode}`);


### PR DESCRIPTION
On Raspberry PI zero W I noticed ~100% CPU usage. Increasing this waiting time reduced it to 4-7% in my node app.